### PR TITLE
Cast id to string to resolve error in add-uebjobvm

### DIFF
--- a/Unitrends/Modules/Add-UebJobVm.ps1
+++ b/Unitrends/Modules/Add-UebJobVm.ps1
@@ -18,7 +18,7 @@ function Add-UebJobVm {
         if($VM -is [String]) {
             $addvm =  Get-UebInventory.ps1 -Name $VM
 		}
-		$vmidstr = $addvm.id.split("_")[-1]
+		$vmidstr = ([string]$addvm.id -split("_"))[-1]
 
 		[int]$vmid = [convert]::ToInt32($vmidstr, 10)
 		


### PR DESCRIPTION
Adding to resolve issue https://github.com/Unitrends/unitrends-pstoolkit/issues/21

Resolves the following error message:

```
Method invocation failed because [System.Int32] does not contain a method named 'split'.
At C:\windows\system32\windowspowershell\v1.0\Modules\Unitrends\Modules\Add-UebJobVm.ps1:21 char:3
+         $vmidstr = $addvm.id.split("_")[-1]
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : MethodNotFound
```